### PR TITLE
Add support for Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+############################################
+## Docker Image for the  OS.js-v2 Project ##
+## Dockerfile created by junland (Github) ##
+############################################
+
+## Pull Docker image using Ubuntu 14.04 LTS ##
+FROM ubuntu:trusty
+MAINTAINER junland ##You can put your own name.##
+USER root
+
+## Initial update of image ##
+RUN apt-get -y update
+
+## Install dependencies and build tools. ##
+RUN apt-get install -y git
+RUN apt-get install -y npm
+RUN apt-get install -y nodejs-legacy
+
+## Clone the Repo and install grunt ##
+RUN git clone https://github.com/andersevenrud/OS.js-v2.git
+RUN npm install -g grunt-cli
+RUN cd OS.js-v2/
+
+## Install and Compile OS.js ##
+WORKDIR OS.js-v2/
+RUN npm install
+RUN grunt
+
+## Start Application and Expose Port ##
+## Note: you can change 'start-node-dev.sh' (Development Version) to 'start-node-dist.sh' (Production Version) ##
+
+CMD ./bin/start-node-dev.sh
+EXPOSE 8000

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,12 +57,32 @@ $ bin\create-windows-symlinks
 
 $ grunt --force
 ```
+## Containers and Virtual Machines
 
-## Vagrant
+### Vagrant
 
 A [Vagrant](https://www.vagrantup.com/) file is also included so you can easily set up a development or testing environment in a Virtual Machine.
 
 Just use [this configuration file](https://raw.githubusercontent.com/andersevenrud/OS.js-v2/master/Vagrantfile).
+
+### Docker
+* Make sure to have `docker.io` installed on your machine.
+* Make sure that you are in the `OS.js-v2` directory.
+* You can change the `Dockerfile` around, I have left comments to help you configure it.
+- Issuing `sudo docker ps` will list all your currently running containers so please refer to this if you forget which container is running your OS.js instance.
+- To stop the container issue `sudo docker stop [Container ID]` in seperate terminal session / window.
+
+1. Issue `sudo docker build -t [Image Name] .` (That's not a mistake, make sure to put that period after the image name or it won't build).
+
+2. If built succesfully you can view your image by issueing the command. `sudo docker images`
+
+3. To start image issue `sudo docker start [Image Name]`.
+
+4. While the image is starting up (You can use this window as a debug console), open up another terminal window and issue `sudo docker inspect -f '{{ .NetworkSettings.IPAddress }}' [Container ID]` which will output a IP address.
+
+5. Lastly, open your favorite web browser and type `[Container IP Address]:8000' into the address bar. This should then direct you to the OS.js Desktop. Enjoy!
+
+* If you don't want to build from a Dockerfile or you want to run it on a Windows machine (via. Kitematic) head on over to https://registry.hub.docker.com/u/junland/osjs-dev/ where I have built and uploaded the development version (Instructions included!).
 
 # Setting up a server
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,20 +67,16 @@ Just use [this configuration file](https://raw.githubusercontent.com/andersevenr
 
 ### Docker
 * Make sure to have `docker.io` installed on your machine.
-* Make sure that you are in the `OS.js-v2` directory.
 * You can change the `Dockerfile` around, I have left comments to help you configure it.
 - Issuing `sudo docker ps` will list all your currently running containers so please refer to this if you forget which container is running your OS.js instance.
-- To stop the container issue `sudo docker stop [Container ID]` in seperate terminal session / window.
 
 1. Issue `sudo docker build -t [Image Name] .` (That's not a mistake, make sure to put that period after the image name or it won't build).
 
-2. If built succesfully you can view your image by issueing the command. `sudo docker images`
+2. If built succesfully you can view your image by issueing the command. `sudo docker start [Image Name]`
 
-3. To start image issue `sudo docker start [Image Name]`.
+3. While the image is starting up (You can use this window as a debug console), open up another terminal window and issue `sudo docker inspect -f '{{ .NetworkSettings.IPAddress }}' [Container ID]` which will output a IP address.
 
-4. While the image is starting up (You can use this window as a debug console), open up another terminal window and issue `sudo docker inspect -f '{{ .NetworkSettings.IPAddress }}' [Container ID]` which will output a IP address.
-
-5. Lastly, open your favorite web browser and type `[Container IP Address]:8000' into the address bar. This should then direct you to the OS.js Desktop. Enjoy!
+4. Lastly, open your favorite web browser and type `[Container IP Address]:8000' into the address bar. This should then direct you to the OS.js Desktop. Enjoy!
 
 * If you don't want to build from a Dockerfile or you want to run it on a Windows machine (via. Kitematic) head on over to https://registry.hub.docker.com/u/junland/osjs-dev/ where I have built and uploaded the development version (Instructions included!).
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ NIX: `curl -sS http://os.js.org/installer | sh`
 
 Windows: http://os.js.org/installer.exe
 
+Docker and Vagrant Support: View `INSTALL.md` for instructions.
+
 Make sure to read the [installation documentation](https://github.com/andersevenrud/OS.js-v2/blob/master/INSTALL.md) before you begin. There you will also find instructions on how to download and install manually.
 
 ## How to contribute

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ NIX: `curl -sS http://os.js.org/installer | sh`
 
 Windows: http://os.js.org/installer.exe
 
-Docker and Vagrant Support: View `INSTALL.md` for instructions.
-
 Make sure to read the [installation documentation](https://github.com/andersevenrud/OS.js-v2/blob/master/INSTALL.md) before you begin. There you will also find instructions on how to download and install manually.
 
 ## How to contribute


### PR DESCRIPTION
![Logo](https://raw.githubusercontent.com/danehans/v3_presentation/gh-pages/images/docker-logo.png)
Was finally able to create a working Docker image for OS.js (Took me several days of trail and error). I also added the working image to the Docker Hub repository and linked the project through there so that the project can also have some presence over in that space (https://registry.hub.docker.com/u/junland/osjs-dev/).

