### PR TITLE
Quick Fix: On chrome, the icon from buttons prevents the drop effect.

### DIFF
--- a/src/client/themes/styles/material/style.less
+++ b/src/client/themes/styles/material/style.less
@@ -273,7 +273,10 @@ gui-button {
     cursor: pointer;
     user-select: none;
     transition: background 0.3s;
-
+    
+    img{
+      pointer-events: none;
+    }
     .drop{
       background: rgba(0, 0, 0, 0.16);
     }


### PR DESCRIPTION
Demo: https://youtu.be/ruhN42qytbs