### PR TITLE
excluding "init" module to be loaded

### DIFF
--- a/src/server/lua/osjs.lua
+++ b/src/server/lua/osjs.lua
@@ -33,7 +33,7 @@ local nixio = require "nixio"
 local fs = require "nixio.fs"
 
 local sys = require "luci.sys"
-local init = require "luci.init"
+--local init = require "luci.init"
 
 local curl = nil
 if pcall(require, "curl") then


### PR DESCRIPTION
the spawning of the "init" module breaks the compatibility with the newer luci releases